### PR TITLE
Adicionando link para código fonte e melhorando bootstrap

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -65,3 +65,10 @@ div.tab-content {border: 1px solid #dfdfdf; border-top: none; margin-bottom: 20p
 
 /*Footer */
 footer {position: relative; bottom: -100px; margin-bottom: 10px;}
+
+/* Separador - é necessário pelo menos um &nbsp; dentro da div */
+.separador {
+	padding-top:1em;
+	padding-bottom:1em;
+}
+

--- a/views/footer.html
+++ b/views/footer.html
@@ -8,7 +8,7 @@
         <p>
           <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">
             <img alt="Licença Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" />
-          </a>O <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Dataset" property="dct:title" rel="dct:type">Mapa colaborativo de PANCs</span> do <a xmlns:cc="http://creativecommons.org/ns#" href="http://kaaete.org" property="cc:attributionName" rel="cc:attributionURL">Ka'a-eté</a> está licenciado com uma Licença <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons - CC BY-SA 4.0 Internacional</a>.</p>
+          </a>O <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Dataset" property="dct:title" rel="dct:type">Mapa colaborativo de PANCs</span> do <a xmlns:cc="http://creativecommons.org/ns#" href="http://kaaete.org" property="cc:attributionName" rel="cc:attributionURL">Ka'a-eté</a> está licenciado com uma Licença <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons - CC BY-SA 4.0 Internacional</a>. {{=A(T("Source code"), _target="_blank", _href="https://github.com/kaaete/web_app/")}}{{=T(" for this website.")}}</a></p>
       </div>
     </footer>
 

--- a/views/header.html
+++ b/views/header.html
@@ -98,4 +98,6 @@
     </header>
     <div class="flash alert alert-dismissable">{{=response.flash or ''}}</div>
 
+	<!-- Esta div serve pra jogar o conteúdo da páginas para baixo, para exibição em computadores que não fazem isto automaticamente. -->
+	<div class="separador">&nbsp;</div>
           


### PR DESCRIPTION
Esses navbars do bootstrap têm um problema em alguns tamanhos de tela que nunca foram consertados, então aquela div com padding joga todo o conteúdo o suficiente pra baixo pra nunca ficar escondido.

Aceitando esse pull request é necessário adicionar traduções, o diretório _languages_ da árvore está vazio pelo .gitignore.
